### PR TITLE
Fix call to displayAward()

### DIFF
--- a/familyconnections/profile.php
+++ b/familyconnections/profile.php
@@ -451,7 +451,7 @@ Event.observe(window, \'load\', function() {
 
         $this->displayHeader($memberId);
 
-        $awards->displayAward($memberId, $type);
+        $this->fcmsAward->displayAward($memberId, $type);
 
         $this->displayFooter($memberId);
     }


### PR DESCRIPTION
Fix the following error when displaying the details of a users award:

PHP Error

Undefined variable: awards

File: /var/www/profile.php

Line: 454

Stack:
#0 __construct called at [/var/www/profile.php:31]
#1 control called at [/var/www/profile.php:72]
#2 displayAward called at [/var/www/profile.php:116]
#3 fcmsErrorHandler called at [/var/www/profile.php:454]
