### PR TITLE
Login issues (fixes #413)

### DIFF
--- a/familyconnections/index.php
+++ b/familyconnections/index.php
@@ -197,7 +197,7 @@ function displayLoginSubmit ()
     }
 
     // New password style
-    if ($row['password'] == 0)
+    if ($row['password'] == '0')
     {
         $hasher = new PasswordHash(8, FALSE);
 


### PR DESCRIPTION
The check for old password style was comparing a string to 0 (integer), which always return true. Fixes #413
