### PR TITLE
Fix chat not working.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@ DjTheG <https://github.com/DjTheG>
 choc
 polliard
 jgraber
+francisbrito <https://github.com/francisbrito>

--- a/familyconnections/inc/chat/index.php
+++ b/familyconnections/inc/chat/index.php
@@ -7,6 +7,9 @@
  * @link https://blueimp.net/ajax/
  */
 
+// Disable displaying errors.
+ini_set('display_errors', 'Off');
+
 // Keep FCMS session
 session_start();
 


### PR DESCRIPTION
It seems error/warning messages are causing issues with HTTP headers being sent by `AJAXChatHttpHeader.php`. 

**Disclaimer**: I'm not a PHP savvy guy, just a JavaScript dev interested in OSS. :)