### PR TITLE
Add support for default avatar when using protected photos

### DIFF
--- a/familyconnections/inc/Upload/Destination/Profile.php
+++ b/familyconnections/inc/Upload/Destination/Profile.php
@@ -46,7 +46,7 @@ class ProfileDestination extends Destination
 
         if (!file_exists($path))
         {
-            $path = URL_PREFIX.'uploads/avatar/no_avatar.jpg';
+            $path = getAvatarPath('no_avatar.jpg', '');
         }
 
         return $path;

--- a/familyconnections/inc/Upload/Profile/Form.php
+++ b/familyconnections/inc/Upload/Profile/Form.php
@@ -82,7 +82,7 @@ class UploadProfileForm
                             <div class="field-label">&nbsp;</div>
                             <div class="field-widget">
                                 <b>'.T_('Default').'</b><br/>
-                                <img id="current-avatar" src="'.URL_PREFIX.'uploads/avatar/no_avatar.jpg" alt="'.T_('Default avatar.').'"/>
+                                <img id="current-avatar" src="'.getAvatarPath('no_avatar.jpg', '').'" alt="'.T_('Default avatar.').'"/>
                             </div>
                         </div>
 

--- a/familyconnections/inc/utils.php
+++ b/familyconnections/inc/utils.php
@@ -3897,7 +3897,14 @@ function getAvatarPath ($avatar, $gravatar)
     }
     else if ($avatar === 'no_avatar.jpg')
     {
-        return URL_PREFIX.'uploads/avatar/no_avatar.jpg';
+        if (defined('UPLOADS'))
+        {
+            return URL_PREFIX.'file.php?a=no_avatar.jpg';
+        }
+        else
+        {
+            return URL_PREFIX.'uploads/avatar/no_avatar.jpg';
+        }
     }
 
     $fcmsError    = FCMS_Error::getInstance();

--- a/familyconnections/inc/utils.php
+++ b/familyconnections/inc/utils.php
@@ -3893,7 +3893,7 @@ function getAvatarPath ($avatar, $gravatar)
 {
     if ($avatar === 'gravatar')
     {
-        return 'http://www.gravatar.com/avatar.php?gravatar_id='.md5(strtolower($gravatar)).'&amp;s=80';
+        return '//www.gravatar.com/avatar.php?gravatar_id='.md5(strtolower($gravatar)).'&amp;s=80';
     }
     else if ($avatar === 'no_avatar.jpg')
     {


### PR DESCRIPTION
When using the protected photos feature the default avatar image links are not always correct as the link is hard-coded to the old location (URL_PREFIX.'uploads/avatar/no_avatar.jpg) in most cases. 

This PR updates the getAvatarPath() function and changes the hard-coded URLs to call that function instead.
