### PR TITLE
Fix hard-coded URLs for no_avatar.jpg

### DIFF
--- a/familyconnections/inc/Upload/Profile/Form.php
+++ b/familyconnections/inc/Upload/Profile/Form.php
@@ -82,7 +82,7 @@ class UploadProfileForm
                             <div class="field-label">&nbsp;</div>
                             <div class="field-widget">
                                 <b>'.T_('Default').'</b><br/>
-                                <img id="current-avatar" src="'.URL_PREFIX.'uploads/avatar/no_avatar.jpg" alt="'.T_('Default avatar.').'"/>
+                                <img id="current-avatar" src="'.getAvatarPath('no_avatar.jpg', '').'" alt="'.T_('Default avatar.').'"/>
                             </div>
                         </div>
 

--- a/familyconnections/inc/utils.php
+++ b/familyconnections/inc/utils.php
@@ -3895,10 +3895,6 @@ function getAvatarPath ($avatar, $gravatar)
     {
         return 'http://www.gravatar.com/avatar.php?gravatar_id='.md5(strtolower($gravatar)).'&amp;s=80';
     }
-    else if ($avatar === 'no_avatar.jpg')
-    {
-        return URL_PREFIX.'uploads/avatar/no_avatar.jpg';
-    }
 
     $fcmsError    = FCMS_Error::getInstance();
     $fcmsDatabase = Database::getInstance($fcmsError);


### PR DESCRIPTION
This fixes the default no_avatar.jpg links when the protected photos feature is used.