### PR TITLE
Change gravatar URL to be compatible with both HTTP and HTTPS sites

### DIFF
--- a/familyconnections/inc/utils.php
+++ b/familyconnections/inc/utils.php
@@ -3893,7 +3893,7 @@ function getAvatarPath ($avatar, $gravatar)
 {
     if ($avatar === 'gravatar')
     {
-        return 'http://www.gravatar.com/avatar.php?gravatar_id='.md5(strtolower($gravatar)).'&amp;s=80';
+        return '//www.gravatar.com/avatar.php?gravatar_id='.md5(strtolower($gravatar)).'&amp;s=80';
     }
     else if ($avatar === 'no_avatar.jpg')
     {


### PR DESCRIPTION
By removing the http: in the image URL the browser will choose the correct method to access the gravatar. This eliminates the browser warnings and broken image links when accessing fcms via HTTPS.