### PR TITLE
Regenerate session id after login

### DIFF
--- a/familyconnections/inc/utils.php
+++ b/familyconnections/inc/utils.php
@@ -2769,6 +2769,12 @@ function loginUser ($userId, $remember)
         return false;
     }
 
+    if (session_id() !== '' && !session_regenerate_id(true))
+    {
+        $fcmsError->setMessage(T_('Could not complete login.'));
+        return false;
+    }
+
     // Setup Cookie/Session
     if ($remember >= 1)
     {


### PR DESCRIPTION
Fixes #537.

This mitigates session fixation by regenerating the PHP session ID after the user credentials have been accepted and the login token has been saved, before writing the authenticated `fcms_id` / `fcms_token` values into `$_SESSION`.

Bounty: targets the $15 Bountysource bounty linked from #537.

Verification:
- `D:\income-bounty-work\tools\php-8.4.21\php.exe -l familyconnections\inc\utils.php`
- `git diff --cached --check` passed before commit.

Note: I could not run the legacy Test-More harness on this Windows/PHP 8.4 setup because the bundled `tests/lib/test-more.php` uses `$this` as a function parameter, which PHP 8 rejects before tests can run.