### PR TITLE
Add multi-day and recurring calendar events

### DIFF
--- a/familyconnections/calendar.php
+++ b/familyconnections/calendar.php
@@ -273,6 +273,13 @@ class Page
         $repeat    = null;
         $private   = 0;
         $invite    = 0;
+        $date      = isset($_POST['date']) ? strip_tags($_POST['date']) : '';
+        $title     = isset($_POST['title']) ? strip_tags($_POST['title']) : '';
+        $desc      = isset($_POST['desc']) ? strip_tags($_POST['desc']) : '';
+        $category  = isset($_POST['category']) ? strip_tags($_POST['category']) : '';
+        $frequency = '';
+        $endDate   = isset($_POST['date-end']) ? strip_tags($_POST['date-end']) : '';
+        $untilDate = isset($_POST['repeat-until']) ? strip_tags($_POST['repeat-until']) : '';
 
         if (isset($_POST['timestart']) and !isset($_POST['all-day']))
         {
@@ -286,6 +293,10 @@ class Page
         {
             $repeat = 'yearly';
         }
+        elseif (isset($_POST['repeat-frequency']))
+        {
+            $frequency = strip_tags($_POST['repeat-frequency']);
+        }
         if (isset($_POST['private']))
         {
             $private = 1;
@@ -295,11 +306,26 @@ class Page
             $invite = 1;
         }
 
-        // Can't make a yearly event also an invitation
-        $notify_user_changed_event = 0;
-        if ($repeat == 'yearly' && $invite == 1)
+        if ($repeat == 'yearly')
         {
-            // Let's turn off the invitation, submit the event and tell the user what we did
+            $endDate   = $date;
+            $frequency = '';
+        }
+
+        $dates = $this->fcmsCalendar->getExpandedEventDates($date, $endDate, $frequency, $untilDate);
+        if (count($dates) <= 0)
+        {
+            $this->displayHeader();
+            loadTemplate('calendar', 'add', array('error' => T_('Invalid Date.')));
+            $this->displayFooter();
+            return;
+        }
+
+        // Can't make a repeating or multi-day event also an invitation.
+        $notify_user_changed_event = 0;
+        if (($repeat == 'yearly' || count($dates) > 1) && $invite == 1)
+        {
+            // Let's turn off the invitation, submit the event and tell the user what we did.
             $invite = 0;
             $notify_user_changed_event = 1;
         }
@@ -310,33 +336,42 @@ class Page
                 ) 
                 VALUES (?, ?, ?, NOW(), ?, ?, ?, ?, ?, ?, ?)";
 
-        $params = array(
-            $_POST['date'], 
-            $timeStart, 
-            $timeEnd, 
-            $_POST['title'], 
-            $_POST['desc'], 
-            $this->fcmsUser->id, 
-            $_POST['category'], 
-            $repeat, 
-            $private, 
-            $invite
-        );
-
-        $id = $this->fcmsDatabase->insert($sql, $params);
-
-        if ($id === false)
+        $eventId = false;
+        foreach ($dates as $date)
         {
-            $this->displayHeader();
-            $this->fcmsError->displayError();
-            $this->displayFooter();
-            return;
+            $params = array(
+                $date,
+                $timeStart,
+                $timeEnd,
+                $title,
+                $desc,
+                $this->fcmsUser->id,
+                $category,
+                $repeat,
+                $private,
+                $invite
+            );
+
+            $insertedId = $this->fcmsDatabase->insert($sql, $params);
+
+            if ($insertedId === false)
+            {
+                $this->displayHeader();
+                $this->fcmsError->displayError();
+                $this->displayFooter();
+                return;
+            }
+
+            if ($eventId === false)
+            {
+                $eventId = $insertedId;
+            }
         }
 
         // Display the invitation screen
         if ($invite == 1)
         {
-            header("Location: calendar.php?invite=$id");
+            header("Location: calendar.php?invite=$eventId");
             return;
         }
 
@@ -353,7 +388,7 @@ class Page
                 'header'   => T_('You cannot invite guests to a repeating event.'),
                 'errors'   => array(
                     T_('Your event was created, but no invitations were sent.'),
-                    T_('Please create a new non-repeating event and invite guests to that.'),
+                    T_('Please create a new single-day non-repeating event and invite guests to that.'),
                 ),
             );
         }
@@ -362,7 +397,7 @@ class Page
             displayOkMessage();
         }
 
-        $this->fcmsCalendar->displayEvent($id, $templateParams);
+        $this->fcmsCalendar->displayEvent($eventId, $templateParams);
         $this->displayFooter();
     }
 

--- a/familyconnections/inc/calendar_class.php
+++ b/familyconnections/inc/calendar_class.php
@@ -1146,6 +1146,105 @@ class Calendar
     }
 
     /**
+     * getExpandedEventDates
+     *
+     * Builds the list of dates to create for multi-day and recurring events.
+     *
+     * @param string $startDate
+     * @param string $endDate
+     * @param string $repeat
+     * @param string $repeatUntil
+     *
+     * @return array
+     */
+    function getExpandedEventDates ($startDate, $endDate = '', $repeat = '', $repeatUntil = '')
+    {
+        $start = $this->getCalendarTimestamp($startDate);
+        if ($start === false)
+        {
+            return array();
+        }
+
+        $end = empty($endDate) ? $start : $this->getCalendarTimestamp($endDate);
+        if ($end === false || $end < $start)
+        {
+            return array();
+        }
+
+        $repeat = strtolower(trim($repeat));
+        if (!in_array($repeat, array('daily', 'weekly', 'monthly')))
+        {
+            $repeat = '';
+        }
+
+        $durationDays = (int)(($end - $start) / 86400);
+        $dates        = array();
+
+        if (empty($repeat))
+        {
+            for ($date = $start; $date <= $end; $date = strtotime('+1 day', $date))
+            {
+                $dates[] = date('Y-m-d', $date);
+            }
+
+            return $dates;
+        }
+
+        $until = $this->getCalendarTimestamp($repeatUntil);
+        if ($until === false || $until < $start)
+        {
+            return array();
+        }
+
+        $intervals = array(
+            'daily'   => '+1 day',
+            'weekly'  => '+1 week',
+            'monthly' => '+1 month',
+        );
+        $interval = $intervals[$repeat];
+        for ($date = $start; $date <= $until; $date = strtotime($interval, $date))
+        {
+            for ($i = 0; $i <= $durationDays; $i++)
+            {
+                $eventDate = strtotime("+$i day", $date);
+                if ($eventDate <= $until)
+                {
+                    $dates[] = date('Y-m-d', $eventDate);
+                }
+            }
+        }
+
+        return array_values(array_unique($dates));
+    }
+
+    /**
+     * getCalendarTimestamp
+     *
+     * @param string $date
+     *
+     * @return int|boolean
+     */
+    private function getCalendarTimestamp ($date)
+    {
+        if (!preg_match('/^\d{4}-\d{1,2}-\d{1,2}$/', $date))
+        {
+            return false;
+        }
+
+        list($year, $month, $day) = explode('-', $date);
+        $year  = (int)$year;
+        $month = (int)$month;
+        $day   = (int)$day;
+
+        if (!checkdate($month, $day, $year))
+        {
+            return false;
+        }
+
+        return mktime(0, 0, 0, $month, $day, $year);
+    }
+
+    /**
      * displayAddForm
      * 
      * Displays the Form to add a new event.

--- a/familyconnections/ui/themes/default/templates/calendar/add.php
+++ b/familyconnections/ui/themes/default/templates/calendar/add.php
@@ -55,6 +55,14 @@
                         <div id="cal-details">
                             <div class="field-row">
                                 <div class="field-label">
+                                    <label for="date-end"><b>End Date</b></label>
+                                </div>
+                                <div class="field-widget">
+                                    <input type="text" id="date-end" name="date-end" size="10">
+                                </div>
+                            </div>
+                            <div class="field-row">
+                                <div class="field-label">
                                     <label for="category"><b><?php echo $TMPL['categoryText']; ?></b></label>
                                 </div>
                                 <div class="field-widget">
@@ -63,6 +71,21 @@
                                         <option value="<?php echo $c['value']; ?>"><?php echo $c['text']; ?></option>
                                 <?php endforeach; ?>
                                     </select>
+                                </div>
+                            </div>
+                            <div class="field-row">
+                                <div class="field-label">
+                                    <label for="repeat-frequency"><b>Repeat</b></label>
+                                </div>
+                                <div class="field-widget">
+                                    <select id="repeat-frequency" name="repeat-frequency">
+                                        <option value="">None</option>
+                                        <option value="daily">Daily</option>
+                                        <option value="weekly">Weekly</option>
+                                        <option value="monthly">Monthly</option>
+                                    </select>
+                                    Repeat Until
+                                    <input type="text" id="repeat-until" name="repeat-until" size="10">
                                 </div>
                             </div>
                             <div class="field-row">


### PR DESCRIPTION
Fixes #377.

This adds calendar creation support for:
- multi-day events by expanding the selected date range into normal calendar rows
- daily, weekly, and monthly recurring events up to a chosen end date
- recurring multi-day spans by preserving the span duration for each occurrence

The implementation avoids a database migration by storing generated occurrences as existing `fcms_calendar` rows, so the current month view, day view, homepage widgets, and exports continue to read the same table shape.

Verification:
- `git diff --check -- familyconnections/calendar.php familyconnections/inc/calendar_class.php familyconnections/ui/themes/default/templates/calendar/add.php` passes locally.
- Codacy Static Code Analysis is passing with 0 new issues.
- Could not run PHP locally because this machine does not have `php`, Composer, or Docker installed on PATH.